### PR TITLE
Magnifier in viewer

### DIFF
--- a/css/magnifier.css
+++ b/css/magnifier.css
@@ -1,5 +1,17 @@
 .magnifier {
-    display: block;
     height: 400px;
     width: 400px;
+}
+
+.magnifier--inline {
+    width: 100%;
+    height: 100%;
+}
+
+.magnifier--inactive {
+    display:  none;
+}
+
+.magnifier--active {
+    display: block;
 }

--- a/gsAIViewer-DZI.html
+++ b/gsAIViewer-DZI.html
@@ -41,6 +41,7 @@
     <script src="js/utils/filterUtils.js"></script>
     <script src="js/utils/geometryUtils.js"></script>
     <script src="js/utils/glUtils.js"></script>
+    <script src="js/utils/magnifier.js"></script>
     <script src="js/ai-viewer.js"></script>
 </head>
 
@@ -488,7 +489,15 @@
                                         <div id="ISS_magnifier" class="magnifier magnifier--square magnifier--active">
                                         </div>
                                         <h4>Settings</h4>
+                                        <div>
+                                            <label>
+                                                <input type="checkbox" name="magnifier__show-in-viewer">
+                                                Show magnifier in viewer
+                                            </label>
+                                        </div>
                                         <h4>Metrics</h4>
+                                        <div class="row">
+                                        </div>
                                     </div>
                                 </div> <!-- end of a main panel -->
                             </div> <!-- end of image-gui-->

--- a/gsAIViewer-DZI.html
+++ b/gsAIViewer-DZI.html
@@ -491,7 +491,7 @@
                                         <h4>Settings</h4>
                                         <div>
                                             <label>
-                                                <input type="checkbox" name="magnifier__show-in-viewer">
+                                                <input type="checkbox" id="magnifier__show-in-viewer">
                                                 Show magnifier in viewer
                                             </label>
                                         </div>

--- a/js/ai-viewer.js
+++ b/js/ai-viewer.js
@@ -21,44 +21,6 @@
     ExactPWD: "bnapora"
 }
 
-tmapp.options_magnifier= {
-    id: "ISS_magnifier",
-    prefixUrl: "openseadragon/images/",
-    showNavigator: false,
-    animationTime: 0.0,
-    blendTime: 0,
-    minZoomLevel: 1,
-    minZoomImageRatio: 1.0,
-    zoomPerClick: 0,
-    constrainDuringPan: true,
-    visibilityRatio: 1,
-    showNavigationControl: false,
-    immediateRender: true,
-    preload: true,
-    panHorizontal: false,
-    panVertical: false,
-    mouseNavEnabled: false
-}
-
-
-tmapp.setupMagnifier = function(prefix, mainViewer) {
-    var mname = prefix + "_magnifier";
-    tmapp.options_magnifier['defaultZoomLevel'] = mainViewer.viewport.getZoom() * 4;
-    tmapp.options_magnifier['minPixelRatio'] = mainViewer.minPixelRatio;
-
-    var magnifier = OpenSeadragon(tmapp.options_magnifier);
-
-    tmapp[mname] = magnifier;
-
-    var syncHandler = function() {
-        magnifier.viewport.zoomTo(mainViewer.viewport.getZoom() * 4); // todo: this number will be configurable
-        magnifier.viewport.panTo(mainViewer.viewport.getCenter());
-    }
-
-    mainViewer.addHandler('zoom', syncHandler);
-    mainViewer.addHandler('pan', syncHandler);
-}
-
 /**
  * Get all the buttons from the interface and assign all the functions associated to them */
 tmapp.registerActions = function () {
@@ -113,7 +75,8 @@ tmapp.init = function () {
     //pixelate because we need the exact values of pixels
     tmapp[vname].addHandler("tile-drawn", OSDViewerUtils.pixelateAtMaximumZoomHandler);
 
-    tmapp.setupMagnifier(op, tmapp[vname]);
+    // Create a new Magnifier, and get its viewer to do things like add annotations
+    tmapp[mname] = new Magnifier(tmapp[vname], tmapp['options_magnifier']).viewer;
 
     if(!tmapp.layers){
         tmapp.layers = [];
@@ -259,4 +222,19 @@ tmapp.options_osd = {
     //     "Authorization": "Basic " + btoa(tmapp.ExactUID + ":" + tmapp.ExactPWD),
     //     // "Accept": "*/*",
     // }
+}
+
+tmapp.options_magnifier= {
+    id: "ISS_magnifier",
+    prefixUrl: "openseadragon/images/",
+    minZoomLevel: 1,
+    minZoomImageRatio: 1.0,
+    zoomPerClick: 0,
+    constrainDuringPan: true,
+    visibilityRatio: 1,
+    preload: true,
+    panHorizontal: false,
+    panVertical: false,
+    mouseNavEnabled: false,
+    magnificationRatio: 4
 }

--- a/js/ai-viewer.js
+++ b/js/ai-viewer.js
@@ -76,7 +76,9 @@ tmapp.init = function () {
     tmapp[vname].addHandler("tile-drawn", OSDViewerUtils.pixelateAtMaximumZoomHandler);
 
     // Create a new Magnifier, and get its viewer to do things like add annotations
-    tmapp[mname] = new Magnifier(tmapp[vname], tmapp['options_magnifier']).viewer;
+    tmapp[mname] = new Magnifier(tmapp[vname], tmapp['options_magnifier']);
+    tmapp[mname + "_main"] = tmapp[mname].viewer;
+    tmapp[mname + "_inline"] = tmapp[mname].inlineViewer;
 
     if(!tmapp.layers){
         tmapp.layers = [];
@@ -87,7 +89,8 @@ tmapp.init = function () {
     var magnifier_svgovname = mname + "_svgov";
 
     tmapp[viewer_svgovname] = tmapp[vname].svgOverlay();
-    tmapp[magnifier_svgovname] = tmapp[mname].svgOverlay();
+    tmapp[magnifier_svgovname] = tmapp[mname].viewer.svgOverlay();
+    // todo: this, but for the inline viewer as well
 
     //main nodes
     const viewer_svgnodeName = vname + "_svgnode";
@@ -141,7 +144,8 @@ tmapp.init = function () {
             console.log('Scrolling has stopped.');
             //
             overlayUtils.modifyDisplayIfAny(vname);
-            overlayUtils.modifyDisplayIfAny(mname);
+            overlayUtils.modifyDisplayIfAny(mname + "_main");
+            overlayUtils.modifyDisplayIfAny(mname + "_inline");
         }, tmapp._scrollDelay);
     }
 
@@ -184,7 +188,9 @@ tmapp.init = function () {
         console.log("Using GPU-based marker drawing (WebGL canvas)")
         // todo: should I make GL an attribute on each OSD viewer instead?
         tmapp['viewerGl'] = new glUtils(tmapp[vname]);
-        tmapp['magGl'] = new glUtils(tmapp[mname]);
+        tmapp['magGl'] = new glUtils(tmapp[mname].viewer);
+        tmapp['inlineMagGl'] = new glUtils(tmapp[mname].inlineViewer);
+
     } else {
         console.log("Using CPU-based marker drawing (SVG canvas)")
     }

--- a/js/utils/dataUtils.js
+++ b/js/utils/dataUtils.js
@@ -140,6 +140,9 @@ dataUtils.processISSRawData = function () {
     if(tmapp['magGl']) {
         tmapp['magGl'].loadMarkers();
     }
+    if(tmapp['inlineMagGl']) {
+        tmapp['inlineMagGl'].loadMarkers();
+    }
 }
 
 /** 

--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -1,191 +1,209 @@
 /**
-* @file magnifier.js A custom magnifier for this app - based loosely on https://github.com/picturae/OpenSeadragonMagnifier
-* @author Melinda Minch
-**/
+ * @file magnifier.js A custom magnifier for this app - based loosely on https://github.com/picturae/OpenSeadragonMagnifier
+ * @author Melinda Minch
+ **/
 
-(function($) {
-    'use strict';
+(function ($) {
+    "use strict";
+
+    //At some browser magnification levels the display regions lines up correctly, but at some there appears to
+    //be a one pixel gap.
+    const fudge = new $.Point(1, 1);
 
     class Magnifier {
         constructor(mainViewer, options) {
             this.mainViewer = mainViewer;
             this.ratio = options.magnificationRatio;
-
             this.element = document.getElementById(options.id);
-
-            options.controlOptions  = $.extend(true, {
-                    anchor:           $.ControlAnchor.NONE,
-                    attachToViewer:   false,
-                    autoFade:         false,
-                }, options.controlOptions || {});
-
             this.element.id = options.id;
+            this.showInViewer = false;
 
-            options = $.extend(true, {
-                sizeRatio:              0.2,
-                viewerWidth: null,
-                viewerHeight: null,
-                minPixelRatio:         this.mainViewer.minPixelRatio,
-                defaultZoomLevel:       this.mainViewer.viewport.getZoom() * this.ratio,
-                minZoomLevel:           1,
-            }, options, {
-                element:                this.element,
-                tabIndex:               -1, // No keyboard navigation, omit from tab order
-                //These need to be overridden to prevent recursion since
-                //the magnifier is a viewer and a viewer has a magnifier/navigator
-                showNavigator:          false,
-                showNavigationControl:  false,
-                showSequenceControl:    false,
-                immediateRender:        true,
-                blendTime:              0,
-                animationTime:          0,
-                autoResize:             options.autoResize,
-                // prevent resizing the magnifier from adding unwanted space around the image
-                minZoomImageRatio:      1.0,
-            });
+            options = $.extend(
+                true,
+                {
+                    sizeRatio: 0.2,
+                    minPixelRatio: this.mainViewer.minPixelRatio,
+                    defaultZoomLevel:
+                        this.mainViewer.viewport.getZoom() * this.ratio,
+                    minZoomLevel: 1,
+                },
+                options,
+                {
+                    element: this.element,
+                    showNavigator: false,
+                    showNavigationControl: false,
+                    showSequenceControl: false,
+                    immediateRender: true,
+                    blendTime: 0,
+                    animationTime: 0,
+                    autoResize: options.autoResize,
+                    // prevent resizing the magnifier from adding unwanted space around the image
+                    minZoomImageRatio: 1.0,
+                }
+            );
 
-            $.setElementTouchActionNone( this.element );
+            this.displayRegion = $.makeNeutralElement("div");
+            this.displayRegion.id = this.element.id + "-displayregion";
+            this.displayRegion.className = "displayregion";
 
-            this.borderWidth = 2;
-            this.viewerWidth = options.viewerWidth;
-            this.viewerHeight = options.viewerHeight;
+            this.displayRegionContainer = $.makeNeutralElement("div");
+            this.displayRegionContainer.id =
+                this.element.id + "-displayregioncontainer";
+            this.displayRegionContainer.className = "displayregioncontainer";
+            this.displayRegionContainer.style.width = "0";
+            this.displayRegionContainer.style.height = "0";
+
+            this.inViewerElement = $.makeNeutralElement("div");
+            this.inViewerElement.id = this.element.id + "--inline";
+            this.inViewerElement.className = 'magnifier magnifier--square magnifier--inactive magnifier--inline'
+
+            this.displayRegionContainer.appendChild(this.displayRegion);
+            this.displayRegion.appendChild(this.inViewerElement);
+            this.mainViewer.canvas.appendChild(this.displayRegionContainer);
+
+            $.setElementTouchActionNone(this.element);
 
             this.borderWidth = 2; // in pixels
 
-            //At some browser magnification levels the display regions lines up correctly, but at some there appears to
-            //be a one pixel gap.
-            this.fudge = new $.Point(1, 1);
-            this.totalBorderWidths = new $.Point(this.borderWidth*2, this.borderWidth*2).minus(this.fudge);
+            this.totalBorderWidths = new $.Point(
+                this.borderWidth * 2,
+                this.borderWidth * 2
+            ).minus(fudge);
 
             this.viewer = $(options);
+            // The same thing again, but inside the viewer instead of outside. It looks better twice as big.
+            this.inlineViewer = $($.extend(
+                options,
+                { element: this.inViewerElement, defaultZoomLevel: options.defaultZoomLevel * 2 })
+            );
 
-            new $.MouseTracker({
-                element:     this.element,
-                dragHandler: $.delegate(this, function (event) {
-                  const viewerSize = $.getElementSize( this.mainViewer.element );
-                  let newWidth = parseInt(this.element.style.width, 10) - event.delta.x;
-                  newWidth = Math.min(newWidth, viewerSize.x * .75);
-                  newWidth = Math.max(newWidth, parseInt(this.element.style.minWidth, 10));
-                  this.element.style.width = newWidth + 'px';
-                  let newHeight = parseInt(this.element.style.height, 10) - event.delta.y;
-                  newHeight = Math.min(newHeight, viewerSize.y * .75);
-                  newHeight = Math.max(newHeight, parseInt(this.element.style.minHeight, 10));
-                  this.element.style.height = newHeight + 'px';
-                }),
-            });
-
-            this.displayRegion           = $.makeNeutralElement( 'div' );
-            this.displayRegion.id        = this.element.id + '-displayregion';
-            this.displayRegion.className = 'displayregion';
-
-            this.displayRegionContainer              = $.makeNeutralElement('div');
-            this.displayRegionContainer.id           = this.element.id + '-displayregioncontainer';
-            this.displayRegionContainer.className    = 'displayregioncontainer';
-            this.displayRegionContainer.style.width  = '0';
-            this.displayRegionContainer.style.height = '0';
-
-            this.displayRegionContainer.appendChild(this.displayRegion);
-            this.mainViewer.canvas.appendChild(this.displayRegionContainer);
-
-            (function( style, borderWidth ){
-                style.position      = 'absolute';
-                style.border        = borderWidth + 'px solid #333';
-                style.margin        = '0px';
-                style.padding       = '0px';
-            }( this.displayRegion.style, this.borderWidth ));
+            (function (style, borderWidth) {
+                style.position = "absolute";
+                style.border = borderWidth + "px solid #333";
+                style.margin = "0px";
+                style.padding = "0px";
+            })(this.displayRegion.style, this.borderWidth);
 
             const self = this;
-            this.mainViewer.addHandler(
-                'zoom',
-                function(){ self.update(); }
-            );
-            this.mainViewer.addHandler(
-                'pan',
-                function(){ self.update(); }
-            );
-
-            this.mainViewer.addHandler('update-level', function() {
+            this.mainViewer.addHandler("zoom", function () {
+                self.update();
+            });
+            this.mainViewer.addHandler("pan", function () {
                 self.update();
             });
 
-            this.mainViewer.addHandler('close', function() {
-                self.close();
-            });
-
-            this.mainViewer.addHandler('full-page', function() {
+            this.mainViewer.addHandler("update-level", function () {
                 self.update();
             });
 
-            this.mainViewer.addHandler('full-screen', function() {
+            this.mainViewer.addHandler("full-page", function () {
                 self.update();
             });
 
-            this.mainViewer.world.addHandler('update-viewport', function() {
+            this.mainViewer.addHandler("full-screen", function () {
                 self.update();
             });
+
+            this.mainViewer.world.addHandler("update-viewport", function () {
+                self.update();
+            });
+
+            document.getElementById('magnifier__show-in-viewer').addEventListener('change', function() {
+                self.toggleInViewer();
+            })
 
             this.storedBounds = null;
             this.update();
         }
 
         update() {
-            var viewerSize = $.getElementSize( this.viewer.element );
-            if ( this._resizeWithViewer && viewerSize.x && viewerSize.y && !viewerSize.equals( this.oldViewerSize ) ) {
-                var newWidth;
-                var newHeight;
-                this.oldViewerSize = viewerSize;
+            const viewerSize = $.getElementSize(this.viewer.element);
+            const inlineViewerSize = $.getElementSize(this.inlineViewer.element);
 
-                if ( this.maintainSizeRatio || !this.elementArea) {
-                    newWidth  = viewerSize.x * this.sizeRatio;
-                    newHeight = viewerSize.y * this.sizeRatio;
-                } else {
-                    newWidth = Math.sqrt(this.elementArea * (viewerSize.x / viewerSize.y));
-                    newHeight = this.elementArea / newWidth;
-                }
+            if (
+                this.mainViewer.viewport &&
+                this.viewer.viewport &&
+                this.inlineViewer.viewport) {
+                    const zoomTarget = this.mainViewer.viewport.getZoom() * this.ratio;
 
-                // When dimensions are suplied with the plugin options
-                if (this.viewerWidth && this.viewerHeight) {
-                    newWidth = this.viewerWidth;
-                    newHeight = this.viewerHeight;
-                }
+                    this.viewer.viewport.zoomTo(zoomTarget);
+                    this.inlineViewer.viewport.zoomTo(zoomTarget * 2);
 
-                this.element.style.width  = Math.round( newWidth ) + 'px';
-                this.element.style.height = Math.round( newHeight ) + 'px';
+                    const center = this.mainViewer.viewport.getCenter();
+                    this.viewer.viewport.panTo(center);
+                    this.inlineViewer.viewport.panTo(center);
 
-                if (!this.elementArea) {
-                    this.elementArea = newWidth * newHeight;
-                }
+                    var bounds = this.viewer.viewport.getBounds(true);
+                    var topleft = this.mainViewer.viewport.pixelFromPoint(
+                        bounds.getTopLeft(),
+                        true
+                    );
+                    var bottomright = this.mainViewer.viewport
+                        .pixelFromPoint(bounds.getBottomRight(), true)
+                        .minus(this.totalBorderWidths);
 
-                this.updateSize();
-            }
+                    //update style for magnifier-box
+                    var style = this.displayRegion.style;
+                    style.display = this.viewer.world.getItemCount()
+                        ? "block"
+                        : "none";
 
-            if (this.mainViewer.viewport && this.viewer.viewport) {
-                this.viewer.viewport.zoomTo(this.mainViewer.viewport.getZoom() * this.ratio);
-                this.viewer.viewport.panTo(this.mainViewer.viewport.getCenter());
+                    style.top = Math.round(topleft.y) + "px";
+                    style.left = Math.round(topleft.x) + "px";
 
-                var bounds      = this.viewer.viewport.getBounds( true );
-                var topleft     = this.mainViewer.viewport.pixelFromPoint( bounds.getTopLeft(), true );
-                var bottomright = this.mainViewer.viewport.pixelFromPoint( bounds.getBottomRight(), true )
-                    .minus( this.totalBorderWidths );
+                    var width = Math.abs(topleft.x - bottomright.x);
+                    var height = Math.abs(topleft.y - bottomright.y);
+                    // make sure width and height are non-negative so IE doesn't throw
+                    style.width = Math.round(Math.max(width, 0)) + "px";
+                    style.height = Math.round(Math.max(height, 0)) + "px";
 
-                //update style for magnifier-box
-                var style = this.displayRegion.style;
-                style.display = this.viewer.world.getItemCount() ? 'block' : 'none';
+                    this.storedBounds = bounds;
 
-                style.top    = Math.round( topleft.y ) + 'px';
-                style.left   = Math.round( topleft.x ) + 'px';
-
-                var width = Math.abs( topleft.x - bottomright.x );
-                var height = Math.abs( topleft.y - bottomright.y );
-                // make sure width and height are non-negative so IE doesn't throw
-                style.width  = Math.round( Math.max( width, 0 ) ) + 'px';
-                style.height = Math.round( Math.max( height, 0 ) ) + 'px';
-
-                this.storedBounds = bounds;
             }
         }
-    };
+
+        toggleInViewer() {
+            if(this.showInViewer) {
+                this.showInViewer = false;
+                $.removeClass(this.inViewerElement, 'magnifier--active');
+                $.addClass(this.inViewerElement, 'magnifier--inactive');
+                this.inlineViewer.setVisible(false);
+            } else {
+                this.showInViewer = true;
+                $.removeClass(this.inViewerElement, 'magnifier--inactive');
+                $.addClass(this.inViewerElement, 'magnifier--active');
+                this.inlineViewer.setVisible(true);
+                this.inlineViewer.forceRedraw();
+            }
+        }
+
+        _createSuccessCallback(i, viewer) {
+            return function(i) {
+                layer0X = viewer.world.getItemAt(0).getContentSize().x;
+                layerNX = viewer.world.getItemAt(viewer.world.getItemCount() - 1).getContentSize().x;
+                viewer.world.getItemAt(viewer.world.getItemCount() -1 ).setWidth(layerNX / layer0X);
+            }
+        }
+
+        addLayer(url_suffix, opacity, layerName, tileSource, i) {
+            url_suffix = url_suffix ? url_suffix : '';
+
+            this.viewer.addTiledImage({
+                index: i + 1,
+                tileSource: url_suffix + tileSource,
+                opacity: opacity,
+                success: this._createSuccessCallback(i, this.viewer)
+            });
+
+            this.inlineViewer.addTiledImage({
+                index: i + 1,
+                tileSource: url_suffix + tileSource,
+                opacity: opacity,
+                success: this._createSuccessCallback(i, this.inlineViewer)
+            });
+        }
+
+
+    }
     window.Magnifier = Magnifier;
-
 })(OpenSeadragon);
-

--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -1,0 +1,191 @@
+/**
+* @file magnifier.js A custom magnifier for this app - based loosely on https://github.com/picturae/OpenSeadragonMagnifier
+* @author Melinda Minch
+**/
+
+(function($) {
+    'use strict';
+
+    class Magnifier {
+        constructor(mainViewer, options) {
+            this.mainViewer = mainViewer;
+            this.ratio = options.magnificationRatio;
+
+            this.element = document.getElementById(options.id);
+
+            options.controlOptions  = $.extend(true, {
+                    anchor:           $.ControlAnchor.NONE,
+                    attachToViewer:   false,
+                    autoFade:         false,
+                }, options.controlOptions || {});
+
+            this.element.id = options.id;
+
+            options = $.extend(true, {
+                sizeRatio:              0.2,
+                viewerWidth: null,
+                viewerHeight: null,
+                minPixelRatio:         this.mainViewer.minPixelRatio,
+                defaultZoomLevel:       this.mainViewer.viewport.getZoom() * this.ratio,
+                minZoomLevel:           1,
+            }, options, {
+                element:                this.element,
+                tabIndex:               -1, // No keyboard navigation, omit from tab order
+                //These need to be overridden to prevent recursion since
+                //the magnifier is a viewer and a viewer has a magnifier/navigator
+                showNavigator:          false,
+                showNavigationControl:  false,
+                showSequenceControl:    false,
+                immediateRender:        true,
+                blendTime:              0,
+                animationTime:          0,
+                autoResize:             options.autoResize,
+                // prevent resizing the magnifier from adding unwanted space around the image
+                minZoomImageRatio:      1.0,
+            });
+
+            $.setElementTouchActionNone( this.element );
+
+            this.borderWidth = 2;
+            this.viewerWidth = options.viewerWidth;
+            this.viewerHeight = options.viewerHeight;
+
+            this.borderWidth = 2; // in pixels
+
+            //At some browser magnification levels the display regions lines up correctly, but at some there appears to
+            //be a one pixel gap.
+            this.fudge = new $.Point(1, 1);
+            this.totalBorderWidths = new $.Point(this.borderWidth*2, this.borderWidth*2).minus(this.fudge);
+
+            this.viewer = $(options);
+
+            new $.MouseTracker({
+                element:     this.element,
+                dragHandler: $.delegate(this, function (event) {
+                  const viewerSize = $.getElementSize( this.mainViewer.element );
+                  let newWidth = parseInt(this.element.style.width, 10) - event.delta.x;
+                  newWidth = Math.min(newWidth, viewerSize.x * .75);
+                  newWidth = Math.max(newWidth, parseInt(this.element.style.minWidth, 10));
+                  this.element.style.width = newWidth + 'px';
+                  let newHeight = parseInt(this.element.style.height, 10) - event.delta.y;
+                  newHeight = Math.min(newHeight, viewerSize.y * .75);
+                  newHeight = Math.max(newHeight, parseInt(this.element.style.minHeight, 10));
+                  this.element.style.height = newHeight + 'px';
+                }),
+            });
+
+            this.displayRegion           = $.makeNeutralElement( 'div' );
+            this.displayRegion.id        = this.element.id + '-displayregion';
+            this.displayRegion.className = 'displayregion';
+
+            this.displayRegionContainer              = $.makeNeutralElement('div');
+            this.displayRegionContainer.id           = this.element.id + '-displayregioncontainer';
+            this.displayRegionContainer.className    = 'displayregioncontainer';
+            this.displayRegionContainer.style.width  = '0';
+            this.displayRegionContainer.style.height = '0';
+
+            this.displayRegionContainer.appendChild(this.displayRegion);
+            this.mainViewer.canvas.appendChild(this.displayRegionContainer);
+
+            (function( style, borderWidth ){
+                style.position      = 'absolute';
+                style.border        = borderWidth + 'px solid #333';
+                style.margin        = '0px';
+                style.padding       = '0px';
+            }( this.displayRegion.style, this.borderWidth ));
+
+            const self = this;
+            this.mainViewer.addHandler(
+                'zoom',
+                function(){ self.update(); }
+            );
+            this.mainViewer.addHandler(
+                'pan',
+                function(){ self.update(); }
+            );
+
+            this.mainViewer.addHandler('update-level', function() {
+                self.update();
+            });
+
+            this.mainViewer.addHandler('close', function() {
+                self.close();
+            });
+
+            this.mainViewer.addHandler('full-page', function() {
+                self.update();
+            });
+
+            this.mainViewer.addHandler('full-screen', function() {
+                self.update();
+            });
+
+            this.mainViewer.world.addHandler('update-viewport', function() {
+                self.update();
+            });
+
+            this.storedBounds = null;
+            this.update();
+        }
+
+        update() {
+            var viewerSize = $.getElementSize( this.viewer.element );
+            if ( this._resizeWithViewer && viewerSize.x && viewerSize.y && !viewerSize.equals( this.oldViewerSize ) ) {
+                var newWidth;
+                var newHeight;
+                this.oldViewerSize = viewerSize;
+
+                if ( this.maintainSizeRatio || !this.elementArea) {
+                    newWidth  = viewerSize.x * this.sizeRatio;
+                    newHeight = viewerSize.y * this.sizeRatio;
+                } else {
+                    newWidth = Math.sqrt(this.elementArea * (viewerSize.x / viewerSize.y));
+                    newHeight = this.elementArea / newWidth;
+                }
+
+                // When dimensions are suplied with the plugin options
+                if (this.viewerWidth && this.viewerHeight) {
+                    newWidth = this.viewerWidth;
+                    newHeight = this.viewerHeight;
+                }
+
+                this.element.style.width  = Math.round( newWidth ) + 'px';
+                this.element.style.height = Math.round( newHeight ) + 'px';
+
+                if (!this.elementArea) {
+                    this.elementArea = newWidth * newHeight;
+                }
+
+                this.updateSize();
+            }
+
+            if (this.mainViewer.viewport && this.viewer.viewport) {
+                this.viewer.viewport.zoomTo(this.mainViewer.viewport.getZoom() * this.ratio);
+                this.viewer.viewport.panTo(this.mainViewer.viewport.getCenter());
+
+                var bounds      = this.viewer.viewport.getBounds( true );
+                var topleft     = this.mainViewer.viewport.pixelFromPoint( bounds.getTopLeft(), true );
+                var bottomright = this.mainViewer.viewport.pixelFromPoint( bounds.getBottomRight(), true )
+                    .minus( this.totalBorderWidths );
+
+                //update style for magnifier-box
+                var style = this.displayRegion.style;
+                style.display = this.viewer.world.getItemCount() ? 'block' : 'none';
+
+                style.top    = Math.round( topleft.y ) + 'px';
+                style.left   = Math.round( topleft.x ) + 'px';
+
+                var width = Math.abs( topleft.x - bottomright.x );
+                var height = Math.abs( topleft.y - bottomright.y );
+                // make sure width and height are non-negative so IE doesn't throw
+                style.width  = Math.round( Math.max( width, 0 ) ) + 'px';
+                style.height = Math.round( Math.max( height, 0 ) ) + 'px';
+
+                this.storedBounds = bounds;
+            }
+        }
+    };
+    window.Magnifier = Magnifier;
+
+})(OpenSeadragon);
+

--- a/js/utils/overlayUtils.js
+++ b/js/utils/overlayUtils.js
@@ -174,16 +174,7 @@ overlayUtils.addLayer = function(layerName, tileSource, i) {
             tmapp[vname].world.getItemAt(tmapp[vname].world.getItemCount()-1).setWidth(layerNX/layer0X);
         }
     });
-    tmapp[mname].addTiledImage({
-        index: i + 1,
-        tileSource: tmapp._url_suffix + tileSource,
-        opacity: opacity,
-        success: function(i) {
-            layer0X = tmapp[mname].world.getItemAt(0).getContentSize().x;
-            layerNX = tmapp[mname].world.getItemAt(tmapp[mname].world.getItemCount()-1).getContentSize().x;
-            tmapp[mname].world.getItemAt(tmapp[mname].world.getItemCount()-1).setWidth(layerNX/layer0X);
-        }
-    });
+    tmapp[mname].addLayer(tmapp.url_suffix, opacity, layerName, tileSource, i)
 }
 
 


### PR DESCRIPTION
todo: this only works with WebGL markers right now, and I'm not sure I like how I have to initialize glUtils for this. SVG support will involve a lot of passing viewer names around, unless I want to convert MarkerUtils to be a class that knows which viewer it's working with, like I did for glUtils.