### PR TITLE
Grid follow on

### DIFF
--- a/gsAIViewer-DZI.html
+++ b/gsAIViewer-DZI.html
@@ -488,6 +488,20 @@
                                     <div class="panel-body">
                                         <div id="ISS_magnifier" class="magnifier">
                                         </div>
+                                        <h3>Markers in Magnifier</h4>
+                                        <div class="row extended-height">
+                                            <table class="table table-striped" style="word-break: break-all;">
+                                                <thead>
+                                                    <tr>
+                                                        <th>Name</th>
+                                                        <th>Count</th>
+                                                        <th>Color</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody id="ISS_magnifier__metrics">
+                                                </tbody>
+                                            </table>
+                                        </div>
                                         <h3>Settings</h3>
                                         <div class="magnifier__setting">
                                             <fieldset id="magnifier__hpf-settings">
@@ -535,20 +549,6 @@
                                                 Magnification Ratio
                                                 <input type="range" min="2" max="20" value="8" step="1" id="magnifier__ratio">
                                             </label>
-                                        </div>
-                                        <h4>Markers in Magnifier</h4>
-                                        <div class="row extended-height">
-                                            <table class="table table-striped" style="word-break: break-all;">
-                                                <thead>
-                                                    <tr>
-                                                        <th>Name</th>
-                                                        <th>Count</th>
-                                                        <th>Color</th>
-                                                    </tr>
-                                                </thead>
-                                                <tbody id="ISS_magnifier__metrics">
-                                                </tbody>
-                                            </table>
                                         </div>
                                     </div>
                                 </div> <!-- end of a main panel -->

--- a/js/ai-viewer.js
+++ b/js/ai-viewer.js
@@ -129,10 +129,6 @@ tmapp.init = function () {
     overlayUtils._d3nodes[magInline_regions] = overlayUtils._d3nodes[magInline_svgnodeName].append("g")
         .attr("id", magInline_regions);
 
-    //overlay for CP data
-    var cpop="CP";                                   //main node;
-    overlayUtils._d3nodes[cpop + "_svgnode"] = overlayUtils._d3nodes[viewer_svgnodeName].append("g")
-        .attr("id", cpop +"_svgnode");
 
     var click_handler = function (event) {
         if (event.quick) {

--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -692,8 +692,8 @@
         }
 
         initializeHpf() {
+            this.storeHpfSideLength();
             if(this.hpf) {
-                this.storeHpfSideLength();
                 this.fitHpfBounds();
             }
         }

--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -756,7 +756,7 @@
                     0.001,
                     this.hpfSideLength,
                     this.hpfSideLength
-            );
+                );
             let row = 0;
 
             // iterate for rows
@@ -790,6 +790,7 @@
                 .style("fill-opacity", 0.0);
 
             const self = this;
+            const strokeWidth = 0.001;
 
             gridRow
                 .selectAll(".square")
@@ -813,13 +814,20 @@
                 })
                 .style("fill-opacity", 0.0)
                 .style("stroke", "#222")
-                .style("stroke-width", 0.001)
+                .style("stroke-width", strokeWidth)
                 .on("click", function (d) {
-                    let bounds = d.bounds.clone();
+                    const topleft = d.bounds.getTopLeft();
 
+                    const bounds = new $.Rect(
+                        topleft.x,
+                        topleft.y,
+                        d.bounds.width - (strokeWidth * 2),
+                        d.bounds.height - (strokeWidth * 2)
+                    );
                     self.viewer.viewport.fitBounds(bounds);
                     self.updateDisplayRegionFromBounds(bounds);
                     self.inlineViewer.viewport.fitBounds(bounds);
+                    overlayUtils.modifyDisplayIfAny(self.mnameMain);
 
                     self.recordPreviousDisplayRegionPosition();
                 });

--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -520,6 +520,7 @@
                 this.fitHpfBounds();
             }
             if (this.hpfGrid) {
+                console.log("Updating grid from zoom handler")
                 this.updateHpfGrid();
             }
             overlayUtils.modifyDisplayIfAny(this.mnameMain);
@@ -596,6 +597,7 @@
                     this.fitHpfBounds();
                 }
                 if (this.hpfGrid) {
+                    console.log("Updating grid from generic update handler")
                     this.updateHpfGrid();
                 }
             }

--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -693,7 +693,7 @@
 
         initializeHpf() {
             this.storeHpfSideLength();
-            if(this.hpf) {
+            if (this.hpf) {
                 this.fitHpfBounds();
             }
         }
@@ -728,7 +728,7 @@
         }
 
         updateHpfGrid() {
-            if(!this.hpfGrid) {
+            if (!this.hpfGrid) {
                 return;
             }
             const hpfBounds = this.mainViewer.world
@@ -739,12 +739,12 @@
             let data = new Array();
             let xpos = 1; //starting xpos and ypos at 1 so the stroke will show when we make the grid below
             let ypos = 1;
-            const width = Math.abs(hpfBounds.x);
+            const width = Math.ceil(Math.abs(hpfBounds.x));
             const height = width; // These are square for now
             const imageDimensions =
                 this.mainViewer.world.getItemAt(0).source.dimensions;
-            const numRows = imageDimensions.y / this.hpfSideLength;
-            const numColumns = imageDimensions.x / this.hpfSideLength;
+            const numRows = Math.ceil(imageDimensions.y / this.hpfSideLength);
+            const numColumns = Math.ceil(imageDimensions.x / this.hpfSideLength);
 
             // iterate for rows
             for (var row = 0; row < numRows; row++) {
@@ -766,7 +766,9 @@
                 // increment the y position for the next row. Move it down by the height
                 ypos += height;
             }
-            d3.select("#" + hpfGridOverlayId).selectAll("svg").remove();
+            d3.select("#" + hpfGridOverlayId)
+                .selectAll("svg")
+                .remove();
             const grid = d3
                 .select("#" + hpfGridOverlayId)
                 .append("svg")
@@ -815,8 +817,8 @@
                     const rect = new $.Rect(
                         d.x + gridOffset.x,
                         d.y + gridOffset.y,
-                        d.width - self.totalBorderWidths.x,
-                        d.height - self.totalBorderWidths.y
+                        d.width - self.borderWidth * 2 + 2,
+                        d.height - self.borderWidth * 2 + 2
                     );
 
                     let bounds =
@@ -836,7 +838,7 @@
         destroyHpfGrid() {
             var elt = document.getElementById(hpfGridOverlayId);
             this.mainViewer.removeOverlay(elt);
-            if(elt) {
+            if (elt) {
                 elt.remove();
             }
         }
@@ -862,7 +864,9 @@
             } else {
                 this.hpfGrid = true;
                 this.showInViewer = false;
-                document.getElementById(checkboxId).setAttribute("disabled", true);
+                document
+                    .getElementById(checkboxId)
+                    .setAttribute("disabled", true);
                 this.showHpfGrid();
             }
         }

--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -775,7 +775,6 @@
                 .enter()
                 .append("g")
                 .attr("class", "grid-row")
-                // .style("fill", "#fff")
                 .style("fill-opacity", 0.0);
 
             const self = this;

--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -788,7 +788,7 @@
             const gridOffset = new $.Point(
                 parseInt(gridOverlayStyles.left, 10),
                 parseInt(gridOverlayStyles.top, 10)
-            );
+            ).minus(fudge);
             gridRow
                 .selectAll(".square")
                 .data(function (d) {
@@ -817,8 +817,8 @@
                     const rect = new $.Rect(
                         d.x + gridOffset.x,
                         d.y + gridOffset.y,
-                        d.width - self.borderWidth * 2 + 2,
-                        d.height - self.borderWidth * 2 + 2
+                        d.width - self.borderWidth,
+                        d.height - self.borderWidth
                     );
 
                     let bounds =

--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -811,29 +811,11 @@
                 .attr("height", function (d) {
                     return d.bounds.height;
                 })
-                // .style("fill", "#fff")
                 .style("fill-opacity", 0.0)
                 .style("stroke", "#222")
                 .style("stroke-width", 0.001)
                 .on("click", function (d) {
-                    const gridOverlayStyles = this.hpfGridOverlay.style;
-                    const gridOffset = new $.Point(
-                        parseInt(gridOverlayStyles.left, 10) - self.borderWidth,
-                        parseInt(gridOverlayStyles.top, 10) - self.borderWidth
-                    );
-
-                    // Snap the bounds of the magnifier to this grid.
-                    const rect = new $.Rect(
-                        d.x + gridOffset.x,
-                        d.y + gridOffset.y,
-                        d.width,
-                        d.height
-                    );
-
-                    let bounds =
-                        self.mainViewer.viewport.viewerElementToViewportRectangle(
-                            rect
-                        );
+                    let bounds = d.bounds.clone();
 
                     self.viewer.viewport.fitBounds(bounds);
                     self.updateDisplayRegionFromBounds(bounds);

--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -741,8 +741,8 @@
             let rectBounds = this.mainViewer.world
                 .getItemAt(0)
                 .imageToViewportRectangle(
-                    0.001,
-                    0.001,
+                    xpos,
+                    ypos,
                     this.hpfSideLength,
                     this.hpfSideLength
                 );

--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -810,8 +810,8 @@
                 const topleft = d.bounds.getTopLeft();
 
                 const bounds = new $.Rect(
-                    topleft.x,
-                    topleft.y,
+                    topleft.x - strokeWidth,
+                    topleft.y - strokeWidth,
                     d.bounds.width - strokeWidth * 2,
                     d.bounds.height - strokeWidth * 2
                 );


### PR DESCRIPTION
Fixing the Chrome bugs in the grid by letting the `svgOverlay` plugin handle almost everything. Also, moved the marker counts to be above the settings in the magnifier sidebar to make the overall view more usable.