### PR TITLE
Grid continued

### DIFF
--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -393,11 +393,6 @@
         }
 
         clickToZoom(event) {
-            if (this.hpfGrid) {
-                // We should let the grid event handlers snap the magnifier
-                // to a grid square instead.
-                return;
-            }
             // Center the magnifiers on a click target, to make
             // it easy to look at annotated cells.
             const target =
@@ -588,8 +583,10 @@
                 const zoomTarget =
                     this.mainViewer.viewport.getZoom() * this.ratio;
 
-                this.viewer.viewport.zoomTo(zoomTarget);
-                this.inlineViewer.viewport.zoomTo(zoomTarget);
+                if (!this.hpf && !this.hpfGrid) {
+                    this.viewer.viewport.zoomTo(zoomTarget);
+                    this.inlineViewer.viewport.zoomTo(zoomTarget);
+                }
 
                 let bounds;
 
@@ -603,8 +600,8 @@
                     // inline / overlay viewer is invisibly pinned to the sidebar viewer
                     bounds = this.viewer.viewport.getBounds();
                     this.updateDisplayRegionFromBounds(bounds);
+                    this.updateCenterMarkerStyle(bounds.getCenter());
                 }
-                this.updateCenterMarkerStyle(bounds.getCenter());
             }
         }
 
@@ -831,8 +828,9 @@
 
             squares.nodes().forEach(function (node) {
                 self.mainViewer.svgOverlay().onClick(node, function (event) {
-                    // we want to catch clicks, not drags
-                    if (event.quick) {
+                    // we want to catch clicks, not drags. We also want people to be
+                    // able to zoom normally if the shift key is down.
+                    if (event.quick && !event.shift) {
                         event.preventDefaultAction = true;
                         const target = d3.select(event.originalTarget);
                         target.style("fill-opacity", 0.0);
@@ -846,11 +844,12 @@
                         );
                         self.viewer.viewport.fitBounds(bounds);
 
-                        self.recordPreviousDisplayRegionPosition();
-
                         const viewer_bounds = self.viewer.viewport.getBounds();
                         self.inlineViewer.viewport.fitBounds(viewer_bounds);
                         self.updateDisplayRegionFromBounds(viewer_bounds);
+                        self.recordPreviousDisplayRegionPosition();
+                    } else if(event.shift) {
+                        self.clickToZoom(event);
                     }
                 });
             });

--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -600,8 +600,8 @@
                     // inline / overlay viewer is invisibly pinned to the sidebar viewer
                     bounds = this.viewer.viewport.getBounds();
                     this.updateDisplayRegionFromBounds(bounds);
-                    this.updateCenterMarkerStyle(bounds.getCenter());
                 }
+                this.updateCenterMarkerStyle(bounds.getCenter());
             }
         }
 

--- a/js/utils/magnifier.js
+++ b/js/utils/magnifier.js
@@ -212,16 +212,10 @@
 
             this.mainViewer.addHandler("resize", function () {
                 self.update();
-                if (self.hpf) {
-                    self.fitHpfBounds();
-                }
             });
 
             this.mainViewer.world.addHandler("update-viewport", function () {
                 self.update();
-                if (self.hpf) {
-                    self.fitHpfBounds();
-                }
             });
 
             this.mainViewer.addHandler("canvas-click", function (event) {
@@ -396,7 +390,6 @@
 
             this.updateDisplayRegionStyle(topleft.y, topleft.x, width, height);
             this.updateCenterMarkerStyle(bounds.getCenter());
-            this.recordPreviousDisplayRegionPosition();
         }
 
         clickToZoom(event) {
@@ -604,7 +597,6 @@
                     // Event handing for when the inline magnifier is active
                     bounds = this.inlineViewer.viewport.getBounds();
                     this.viewer.viewport.fitBounds(bounds);
-                    this.updateCenterMarkerStyle(bounds.getCenter());
                 } else if (this.hpf) {
                     this.fitHpfBounds();
                 } else {
@@ -612,6 +604,7 @@
                     bounds = this.viewer.viewport.getBounds();
                     this.updateDisplayRegionFromBounds(bounds);
                 }
+                this.updateCenterMarkerStyle(bounds.getCenter());
             }
         }
 
@@ -852,6 +845,8 @@
                             d.bounds.height - strokeWidth
                         );
                         self.viewer.viewport.fitBounds(bounds);
+
+                        self.recordPreviousDisplayRegionPosition();
 
                         const viewer_bounds = self.viewer.viewport.getBounds();
                         self.inlineViewer.viewport.fitBounds(viewer_bounds);


### PR DESCRIPTION
- Fix the bug where the viewer resizes on pan in grid mode
- Add an option to shift-click in grid mode to not snap to the grid